### PR TITLE
Launcher box sizes

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.AEL" name="Advanced Emulator Launcher (dev version)" version="0.10.0-alpha.51" provider-name="Wintermute0110">
+<addon id="plugin.program.AEL" name="Advanced Emulator Launcher (dev version)" version="0.10.0-alpha.52" provider-name="Wintermute0110">
   <requires>
     <!--
         See https://github.com/xbmc/xbmc/blob/master/addons/xbmc.python/addon.xml

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.AEL" name="Advanced Emulator Launcher (dev version)" version="0.10.0-alpha.50" provider-name="Wintermute0110">
+<addon id="plugin.program.AEL" name="Advanced Emulator Launcher (dev version)" version="0.10.0-alpha.51" provider-name="Wintermute0110">
   <requires>
     <!--
         See https://github.com/xbmc/xbmc/blob/master/addons/xbmc.python/addon.xml

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.AEL" name="Advanced Emulator Launcher (dev version)" version="0.10.0-alpha.52" provider-name="Wintermute0110">
+<addon id="plugin.program.AEL" name="Advanced Emulator Launcher (dev version)" version="0.10.0-alpha.53" provider-name="Wintermute0110">
   <requires>
     <!--
         See https://github.com/xbmc/xbmc/blob/master/addons/xbmc.python/addon.xml

--- a/resources/constants.py
+++ b/resources/constants.py
@@ -347,6 +347,26 @@ ROM_ASSET_ID_LIST = [
     ASSET_TRAILER_ID,
 ]
 
+BOX_SIZE_COVER      = 'Cover'
+BOX_SIZE_WIDE       = 'Widebox'
+BOX_SIZE_BLURAY     = 'Bluray'
+BOX_SIZE_CD         = 'CD'
+BOX_SIZE_SLIM       = 'Slimbox'
+BOX_SIZE_STEAM      = 'SteamBanner'
+BOX_SIZE_SCREEN     = 'Screenshot'
+BOX_SIZE_THUMB      = 'Thumb'
+
+BOX_SIZES = [
+    BOX_SIZE_COVER,
+    BOX_SIZE_BLURAY,
+    BOX_SIZE_WIDE,
+    BOX_SIZE_CD,
+    BOX_SIZE_SLIM,
+    BOX_SIZE_STEAM,
+    BOX_SIZE_SCREEN,
+    BOX_SIZE_THUMB
+]
+
 # --- Addon will search these file extensions for assets ---
 # >> Check http://kodi.wiki/view/advancedsettings.xml#videoextensions
 IMAGE_EXTENSION_LIST   = ['png', 'jpg', 'gif', 'bmp']

--- a/resources/constants.py
+++ b/resources/constants.py
@@ -129,6 +129,7 @@ AEL_CONTENT_VALUE_NONE         = ''
 AEL_LAUNCHER_NAME_LABEL        = 'AEL_Launch_Name'
 AEL_LAUNCHER_ICON_LABEL        = 'AEL_Launch_Icon'
 AEL_LAUNCHER_CLEARLOGO_LABEL   = 'AEL_Launch_Clearlogo'
+AEL_LAUNCHER_BOXSIZE_LABEL     = 'AEL_Launch_Boxsize'
 
 # Value is the number of items inside a launcher.
 AEL_NUMITEMS_LABEL             = 'AEL_NumItems'
@@ -347,24 +348,28 @@ ROM_ASSET_ID_LIST = [
     ASSET_TRAILER_ID,
 ]
 
-BOX_SIZE_COVER      = 'Cover'
-BOX_SIZE_WIDE       = 'Widebox'
-BOX_SIZE_BLURAY     = 'Bluray'
-BOX_SIZE_CD         = 'CD'
-BOX_SIZE_SLIM       = 'Slimbox'
-BOX_SIZE_STEAM      = 'SteamBanner'
-BOX_SIZE_SCREEN     = 'Screenshot'
-BOX_SIZE_THUMB      = 'Thumb'
+BOX_SIZE_POSTER     = 'poster'
+BOX_SIZE_WIDE       = 'widebox'
+BOX_SIZE_DVD        = 'dvd'
+BOX_SIZE_BLURAY     = 'bluray'
+BOX_SIZE_CD         = 'cd'
+BOX_SIZE_SLIM       = 'slimbox'
+BOX_SIZE_SQUARE     = 'squarebox'
+BOX_SIZE_STEAM      = 'steambanner'
+BOX_SIZE_SCREEN     = 'screenshot'
+BOX_SIZE_THUMBNAIL  = 'thumbnail'
 
 BOX_SIZES = [
-    BOX_SIZE_COVER,
+    BOX_SIZE_POSTER,
+    BOX_SIZE_DVD,
     BOX_SIZE_BLURAY,
     BOX_SIZE_WIDE,
     BOX_SIZE_CD,
     BOX_SIZE_SLIM,
+    BOX_SIZE_SQUARE,
     BOX_SIZE_STEAM,
     BOX_SIZE_SCREEN,
-    BOX_SIZE_THUMB
+    BOX_SIZE_THUMBNAIL
 ]
 
 # --- Addon will search these file extensions for assets ---

--- a/resources/constants.py
+++ b/resources/constants.py
@@ -129,6 +129,7 @@ AEL_CONTENT_VALUE_NONE         = ''
 AEL_LAUNCHER_NAME_LABEL        = 'AEL_Launch_Name'
 AEL_LAUNCHER_ICON_LABEL        = 'AEL_Launch_Icon'
 AEL_LAUNCHER_CLEARLOGO_LABEL   = 'AEL_Launch_Clearlogo'
+AEL_LAUNCHER_PLATFORM_LABEL    = 'AEL_Launch_Platform'
 AEL_LAUNCHER_BOXSIZE_LABEL     = 'AEL_Launch_Boxsize'
 
 # Value is the number of items inside a launcher.
@@ -349,27 +350,27 @@ ROM_ASSET_ID_LIST = [
 ]
 
 BOX_SIZE_POSTER     = 'poster'
-BOX_SIZE_WIDE       = 'widebox'
 BOX_SIZE_DVD        = 'dvd'
 BOX_SIZE_BLURAY     = 'bluray'
 BOX_SIZE_CD         = 'cd'
+BOX_SIZE_WIDE       = 'widebox'
 BOX_SIZE_SLIM       = 'slimbox'
 BOX_SIZE_SQUARE     = 'squarebox'
+BOX_SIZE_3DS        = '3dsbox'
 BOX_SIZE_STEAM      = 'steambanner'
 BOX_SIZE_SCREEN     = 'screenshot'
-BOX_SIZE_THUMBNAIL  = 'thumbnail'
 
 BOX_SIZES = [
     BOX_SIZE_POSTER,
     BOX_SIZE_DVD,
     BOX_SIZE_BLURAY,
-    BOX_SIZE_WIDE,
     BOX_SIZE_CD,
+    BOX_SIZE_WIDE,
     BOX_SIZE_SLIM,
     BOX_SIZE_SQUARE,
+    BOX_SIZE_3DS,
     BOX_SIZE_STEAM,
-    BOX_SIZE_SCREEN,
-    BOX_SIZE_THUMBNAIL
+    BOX_SIZE_SCREEN
 ]
 
 # --- Addon will search these file extensions for assets ---

--- a/resources/main.py
+++ b/resources/main.py
@@ -5261,6 +5261,7 @@ def m_subcommand_rescrape_rom_assets(rom):
     
     # --- Make a menu list of available asset scrapers ---
     options =  g_ScraperFactory.get_asset_scraper_menu_list()
+    options[SCRAPER_NULL_ID] = 'Scrape assets from local folder'
     selected_option = KodiOrdDictionaryDialog().select('Rescrape ROM assets', options)
     if selected_option is None:
         # >> Exits context menu
@@ -5272,10 +5273,10 @@ def m_subcommand_rescrape_rom_assets(rom):
     scraper_settings = ScraperSettings()
     scraper_settings.assets_scraper_ID       = selected_option
     scraper_settings.scrape_metadata_policy  = SCRAPE_ACTION_NONE
-    scraper_settings.scrape_assets_policy    = SCRAPE_POLICY_SCRAPE_ONLY
-    scraper_settings.search_term_mode        = SCRAPE_MANUAL
-    scraper_settings.game_selection_mode     = SCRAPE_MANUAL
-    scraper_settings.asset_selection_mode    = SCRAPE_MANUAL
+    scraper_settings.scrape_assets_policy    = SCRAPE_POLICY_SCRAPE_ONLY if selected_option != SCRAPER_NULL_ID else SCRAPE_POLICY_LOCAL_ONLY
+    scraper_settings.search_term_mode        = SCRAPE_MANUAL if selected_option != SCRAPER_NULL_ID else SCRAPE_AUTOMATIC
+    scraper_settings.game_selection_mode     = SCRAPE_MANUAL if selected_option != SCRAPER_NULL_ID else SCRAPE_AUTOMATIC
+    scraper_settings.asset_selection_mode    = SCRAPE_MANUAL if selected_option != SCRAPER_NULL_ID else SCRAPE_AUTOMATIC
     
     pdialog             = KodiProgressDialog()
     ROM_file            = rom.get_file()
@@ -7795,11 +7796,10 @@ def m_gui_render_rom_row(categoryID, launcher, rom,
     # labels are set as Title in setInfo(), then they work but the alphabetical order is lost!
     # I solved this alphabetical ordering issue by placing a coloured tag [Fav] at the and of the ROM name
     # instead of changing the whole row colour.
-    trailer = rom.get_asset_str(asset_id=ASSET_TRAILER_ID)    
-    listitem.setInfo('video', {'title'   : rom_name,
+    listitem.setInfo('video', { 'title'   : rom_name,
                                 'genre'   : rom.get_genre(),  'studio'  : rom.get_developer(),
                                 'rating'  : rom.get_rating(), 'plot'    : rom.get_plot(),
-                                'trailer' : trailer,          'overlay' : ICON_OVERLAY })
+                                'trailer' : rom.get_trailer(),'overlay' : ICON_OVERLAY })
     
     # >> BUG in Jarvis/Krypton skins. If 'year' is set to empty string a 0 is displayed on the
     # >>     skin. If year is not set then the correct icon is shown.

--- a/resources/main.py
+++ b/resources/main.py
@@ -4048,6 +4048,10 @@ def m_subcommand_launcher_metadata_rating(category, launcher):
 @router.action('EDIT_METADATA_PLOT')
 def m_subcommand_launcher_metadata_plot(category, launcher):
     m_gui_edit_field_by_str(launcher, 'Plot', launcher.get_plot, launcher.set_plot)
+
+@router.action('EDIT_METADATA_BOXSIZE')
+def m_subcommand_launcher_metadata_boxsize(category, launcher):
+    m_gui_edit_field_by_list(launcher, 'Default box size', BOX_SIZES, launcher.get_box_sizing, launcher.set_box_sizing)
     
 # --- Import launcher metadata from NFO file (default location) ---
 @router.action('IMPORT_NFO_FILE_DEFAULT')
@@ -5152,6 +5156,10 @@ def m_subcommand_edit_rom_rating(launcher, rom):
 @router.action('EDIT_METADATA_PLOT')
 def m_subcommand_edit_rom_description(launcher, rom):
     m_gui_edit_field_by_str(rom, 'plot', rom.get_plot, rom.update_plot)
+
+@router.action('EDIT_METADATA_BOXSIZE')
+def m_subcommand_edit_rom_boxsize(launcher, rom):
+    m_gui_edit_field_by_list(rom, 'Box size', BOX_SIZES, rom.get_box_sizing, rom.set_box_sizing)
 
 # --- Import of the rom game plot from TXT file ---
 @router.action('LOAD_PLOT')
@@ -7590,6 +7598,7 @@ def m_gui_render_launcher_row(launcher, launcher_raw_name = None):
                                    'genre'   : launcher_dic['m_genre'],   'studio'  : launcher_dic['m_developer'],
                                    'rating'  : launcher_dic['m_rating'],  'plot'    : launcher_dic['m_plot'],
                                    'trailer' : launcher_dic['s_trailer'], 'overlay' : ICON_OVERLAY })
+    
     listitem.setProperty('platform', launcher_dic['platform'])
     if launcher_dic['rompath']:
         listitem.setProperty(AEL_CONTENT_LABEL, AEL_CONTENT_VALUE_ROM_LAUNCHER)
@@ -7795,6 +7804,7 @@ def m_gui_render_rom_row(categoryID, launcher, rom,
     listitem.setProperty('nplayers', rom.get_number_of_players())
     listitem.setProperty('esrb', rom.get_esrb_rating())
     listitem.setProperty('platform', platform)
+    listitem.setProperty('boxsize', rom.get_box_sizing())
     listitem.setProperty(AEL_CONTENT_LABEL, AEL_CONTENT_VALUE_ROM)
 
     # --- Set ROM artwork ---

--- a/resources/main.py
+++ b/resources/main.py
@@ -6682,15 +6682,18 @@ def m_misc_set_AEL_Launcher_Content(launcher):
     kodi_thumb     = 'DefaultFolder.png' if launcher.supports_launching_roms() else 'DefaultProgram.png'
     icon_path      = launcher.get_mapped_asset_str(asset_id=ASSET_ICON_ID, fallback=kodi_thumb)
     clearlogo_path = launcher.get_mapped_asset_str(asset_id=ASSET_CLEARLOGO_ID)
+    
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_NAME_LABEL, launcher.get_name())
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_ICON_LABEL, icon_path)
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_CLEARLOGO_LABEL, clearlogo_path)
+    xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_PLATFORM_LABEL, launcher.get_platform())
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_BOXSIZE_LABEL, launcher.get_box_sizing())
 
 def m_misc_clear_AEL_Launcher_Content():
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_NAME_LABEL, '')
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_ICON_LABEL, '')
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_CLEARLOGO_LABEL, '')
+    xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_PLATFORM_LABEL, '')
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_BOXSIZE_LABEL, '')
     
 #

--- a/resources/main.py
+++ b/resources/main.py
@@ -1170,7 +1170,7 @@ def m_command_render_roms(categoryID, launcherID):
     # --- Set content type and sorting methods ---
     m_misc_set_all_sorting_methods()
     m_misc_set_AEL_Content(AEL_CONTENT_VALUE_ROMS)
-    # m_misc_set_AEL_Launcher_Content(selectedLauncher)
+    m_misc_set_AEL_Launcher_Content(launcher)
 
     # --- Render in Flat mode (all ROMs) or Parent/Clone or 1G1R mode---
     # >> Parent/Clone mode and 1G1R modes are very similar in terms of programming.
@@ -6677,19 +6677,22 @@ def m_misc_set_AEL_Content(AEL_Content_Value):
 #   1. Title of the launcher.
 #   2. Icon of the launcher.
 #   3. Clearlogo of the launcher.
-#   ---- TODO Deprecated?
-def m_misc_set_AEL_Launcher_Content(launcher_dic):
-    kodi_thumb     = 'DefaultFolder.png' if launcher_dic['rompath'] else 'DefaultProgram.png'
-    #icon_path      = asset_get_default_asset_Category(launcher_dic, 'default_icon', kodi_thumb)
-    #clearlogo_path = asset_get_default_asset_Category(launcher_dic, 'default_clearlogo')
-    xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_NAME_LABEL, launcher_dic['m_name'])
+#   4. Default box size of the launcher
+def m_misc_set_AEL_Launcher_Content(launcher):
+    kodi_thumb     = 'DefaultFolder.png' if launcher.supports_launching_roms() else 'DefaultProgram.png'
+    icon_path      = launcher.get_mapped_asset_str(asset_id=ASSET_ICON_ID, fallback=kodi_thumb)
+    clearlogo_path = launcher.get_mapped_asset_str(asset_id=ASSET_CLEARLOGO_ID)
+    xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_NAME_LABEL, launcher.get_name())
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_ICON_LABEL, icon_path)
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_CLEARLOGO_LABEL, clearlogo_path)
+    xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_BOXSIZE_LABEL, launcher.get_box_sizing())
 
 def m_misc_clear_AEL_Launcher_Content():
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_NAME_LABEL, '')
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_ICON_LABEL, '')
     xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_CLEARLOGO_LABEL, '')
+    xbmcgui.Window(AEL_CONTENT_WINDOW_ID).setProperty(AEL_LAUNCHER_BOXSIZE_LABEL, '')
+    
 #
 # Edits an object field which is a Unicode string.
 #

--- a/resources/main.py
+++ b/resources/main.py
@@ -4164,6 +4164,10 @@ def m_scraper_settings_asset_selection_mode(category, launcher, scraper_settings
     
     scraper_settings.asset_selection_mode = selected_option
 
+@router.action('SC_OVERWRITE_MODE')
+def m_scraper_settings_overwrite_mode(category, launcher, scraper_settings):  
+    scraper_settings.overwrite_existing = not scraper_settings.overwrite_existing
+
 @router.action('SC_METADATA_SCRAPER')
 def m_scraper_settings_metadata_scraper(category, launcher, scraper_settings):    
     options = g_ScraperFactory.get_metadata_scraper_menu_list()
@@ -5277,6 +5281,7 @@ def m_subcommand_rescrape_rom_assets(rom):
     scraper_settings.search_term_mode        = SCRAPE_MANUAL if selected_option != SCRAPER_NULL_ID else SCRAPE_AUTOMATIC
     scraper_settings.game_selection_mode     = SCRAPE_MANUAL if selected_option != SCRAPER_NULL_ID else SCRAPE_AUTOMATIC
     scraper_settings.asset_selection_mode    = SCRAPE_MANUAL if selected_option != SCRAPER_NULL_ID else SCRAPE_AUTOMATIC
+    scraper_settings.overwrite_existing      = kodi_dialog_yesno('Overwrite existing assets settings?')
     
     pdialog             = KodiProgressDialog()
     ROM_file            = rom.get_file()
@@ -6034,7 +6039,7 @@ def m_command_exec_utils_check_launcher_sync_status():
         pdialog.updateMessage2('Scanning files in ROM paths...')
         launcher_path = FileName(launcher['rompath'])
         log_debug('Scanning files in {}'.format(launcher_path.getPath()))
-        if self.settings['scan_recursive']:
+        if g_settings['scan_recursive']:
             log_debug('Recursive scan activated')
             files = launcher_path.recursiveScanFilesInPath('*.*')
         else:
@@ -7093,6 +7098,7 @@ def m_gui_edit_asset(obj_instance, asset_info):
         scraper_settings.game_selection_mode     = SCRAPE_MANUAL
         scraper_settings.asset_selection_mode    = SCRAPE_MANUAL
         scraper_settings.asset_IDs_to_scrape     = [asset_info.id]
+        scraper_settings.overwrite_existing      = kodi_dialog_yesno('Overwrite existing assets settings?')
         
         rom                 = obj_instance
         pdialog             = KodiProgressDialog()

--- a/resources/objects.py
+++ b/resources/objects.py
@@ -1567,7 +1567,7 @@ class ROM(MetaDataItemABC):
         if 'box_size' in self.entity_data: return self.entity_data['box_size'] 
         # fallback to launcher size 
         if self.launcher: return self.launcher.get_box_sizing()
-        return BOX_SIZE_COVER
+        return BOX_SIZE_POSTER
     
     def set_box_sizing(self, box_size):
         self.entity_data['box_size'] = box_size
@@ -2154,7 +2154,7 @@ class LauncherABC(MetaDataItemABC):
     def update_report_timestamp(self): self.entity_data['timestamp_report'] = time.time()
 
     def get_box_sizing(self):
-        return self.entity_data['box_size'] if 'box_size' in self.entity_data else BOX_SIZE_COVER
+        return self.entity_data['box_size'] if 'box_size' in self.entity_data else BOX_SIZE_POSTER
     
     def set_box_sizing(self, box_size):
         self.entity_data['box_size'] = box_size
@@ -2385,7 +2385,6 @@ class StandaloneLauncher(LauncherABC):
             self._builder_get_title_from_app_path)
         wizard = WizardDialog_Selection(wizard, 'platform', 'Select the platform',
             AEL_platform_list)
-
         return wizard
 
     def _build_pre_wizard_hook(self): return True
@@ -2543,6 +2542,10 @@ class ROMLauncherABC(LauncherABC):
         # >> launcher is edited using Python passing by assignment.
         self.rom_assets_init_dirs()
 
+        # --- Determine box size based on platform --
+        platform = get_AEL_platform(self.entity_data['platform'])
+        self.set_box_sizing(platform.default_box_size)
+        
         return True
 
     def _builder_get_extensions_from_app_path(self, input, item_key ,launcher):
@@ -4314,13 +4317,17 @@ class NvidiaGameStreamLauncher(ROMLauncherABC):
     
     def _build_pre_wizard_hook(self):
         log_debug('NvidiaGameStreamLauncher::_build_pre_wizard_hook() Starting ...')
-
         return True
 
     def _build_post_wizard_hook(self):
         log_debug('NvidiaGameStreamLauncher::_build_post_wizard_hook() Starting ...')
 
-        return super(NvidiaGameStreamLauncher, self)._build_post_wizard_hook()
+        success = super(NvidiaGameStreamLauncher, self)._build_post_wizard_hook()
+        if not success:
+            return success
+        
+        self.set_box_sizing(BOX_SIZE_STEAM)
+        return success
     
     def _builder_generatePairPinCode(self, input, item_key, launcher):
         return GameStreamServer(None, None).generatePincode()

--- a/resources/objects.py
+++ b/resources/objects.py
@@ -1563,6 +1563,15 @@ class ROM(MetaDataItemABC):
     def set_alternative_arguments(self, arg):
         self.entity_data['altarg'] = arg
 
+    def get_box_sizing(self):        
+        if 'box_size' in self.entity_data: return self.entity_data['box_size'] 
+        # fallback to launcher size 
+        if self.launcher: return self.launcher.get_box_sizing()
+        return BOX_SIZE_COVER
+    
+    def set_box_sizing(self, box_size):
+        self.entity_data['box_size'] = box_size
+
     def copy(self):
         data = self.copy_of_data_dic()
         return ROM(data, self.launcher)
@@ -1713,10 +1722,11 @@ class ROM(MetaDataItemABC):
         options['EDIT_METADATA_DEVELOPER']   = u"Edit Developer: '{0}'".format(self.get_developer()).encode('utf-8')
         options['EDIT_METADATA_NPLAYERS']    = u"Edit NPlayers: '{0}'".format(self.get_number_of_players()).encode('utf-8')
         options['EDIT_METADATA_ESRB']        = u"Edit ESRB rating: '{0}'".format(self.get_esrb_rating()).encode('utf-8')
-        options['EDIT_METADATA_RATING']      = u"Edit Rating: '{0}'".format(rating).encode('utf-8')
-        options['EDIT_METADATA_PLOT']        = u"Edit Plot: '{0}'".format(plot_str).encode('utf-8')
+        options['EDIT_METADATA_RATING']      = u"Edit Rating: '{}'".format(rating).encode('utf-8')
+        options['EDIT_METADATA_PLOT']        = u"Edit Plot: '{}'".format(plot_str).encode('utf-8')
+        options['EDIT_METADATA_BOXSIZE']     = u"Edit Box Size: '{}'".format(self.get_box_sizing())
         options['LOAD_PLOT']                 = "Load Plot from TXT file ..."
-        options['IMPORT_NFO_FILE']           = u"Import NFO file (default, {0})".format(NFO_found_str).encode('utf-8')
+        options['IMPORT_NFO_FILE']           = u"Import NFO file (default, {})".format(NFO_found_str).encode('utf-8')
         options['SAVE_NFO_FILE']             = "Save NFO file (default location)"
         options['SCRAPE_ROM_METADATA']       = "Scrape Metadata"
 
@@ -1911,14 +1921,15 @@ class LauncherABC(MetaDataItemABC):
         NFO_found_str = 'NFO found' if NFO_FileName.exists() else 'NFO not found'
 
         options = collections.OrderedDict()
-        options['EDIT_METADATA_TITLE']       = "Edit Title: '{0}'".format(self.get_name())
-        options['EDIT_METADATA_PLATFORM']    = "Edit Platform: {0}".format(self.entity_data['platform'])
-        options['EDIT_METADATA_RELEASEYEAR'] = "Edit Release Year: '{0}'".format(self.entity_data['m_year'])
-        options['EDIT_METADATA_GENRE']       = "Edit Genre: '{0}'".format(self.entity_data['m_genre'])
-        options['EDIT_METADATA_DEVELOPER']   = "Edit Developer: '{0}'".format(self.entity_data['m_developer'])
-        options['EDIT_METADATA_RATING']      = "Edit Rating: '{0}'".format(rating)
-        options['EDIT_METADATA_PLOT']        = "Edit Plot: '{0}'".format(plot_str)
-        options['IMPORT_NFO_FILE']           = 'Import NFO file (default {0})'.format(NFO_found_str)
+        options['EDIT_METADATA_TITLE']       = "Edit Title: '{}'".format(self.get_name())
+        options['EDIT_METADATA_PLATFORM']    = "Edit Platform: {}".format(self.entity_data['platform'])
+        options['EDIT_METADATA_RELEASEYEAR'] = "Edit Release Year: '{}'".format(self.entity_data['m_year'])
+        options['EDIT_METADATA_GENRE']       = "Edit Genre: '{}'".format(self.entity_data['m_genre'])
+        options['EDIT_METADATA_DEVELOPER']   = "Edit Developer: '{}'".format(self.entity_data['m_developer'])
+        options['EDIT_METADATA_RATING']      = "Edit Rating: '{}'".format(rating)
+        options['EDIT_METADATA_PLOT']        = "Edit Plot: '{}'".format(plot_str)
+        options['EDIT_METADATA_BOXSIZE']     = "Edit Box Size: '{}'".format(self.get_box_sizing())
+        options['IMPORT_NFO_FILE']           = 'Import NFO file (default {})'.format(NFO_found_str)
         options['IMPORT_NFO_FILE_BROWSE']    = 'Import NFO file (browse NFO file) ...'
         options['SAVE_NFO_FILE']             = 'Save NFO file (default location)'
 
@@ -2141,6 +2152,12 @@ class LauncherABC(MetaDataItemABC):
         return float(timestamp)
 
     def update_report_timestamp(self): self.entity_data['timestamp_report'] = time.time()
+
+    def get_box_sizing(self):
+        return self.entity_data['box_size'] if 'box_size' in self.entity_data else BOX_SIZE_COVER
+    
+    def set_box_sizing(self, box_size):
+        self.entity_data['box_size'] = box_size
 
     # ---------------------------------------------------------------------------------------------
     # Launcher asset methods

--- a/resources/platforms.py
+++ b/resources/platforms.py
@@ -16,6 +16,8 @@
 # --- Python standard library ---
 from __future__ import unicode_literals
 
+from resources.constants import *
+
 # -------------------------------------------------------------------------------------------------
 # New platform engine
 # -------------------------------------------------------------------------------------------------
@@ -34,19 +36,20 @@ PLATFORM_UNKNOWN_COMPACT = 'unknown'
 class Platform:
     def __init__(self, name, shortname, compactname, aliasof = None,
         TGDB_plat = None, MG_plat = None, SS_plat = None, GF_plat = None,
-        DAT = DAT_NONE, DAT_prefix = ''):
+        DAT = DAT_NONE, DAT_prefix = '', default_box_size = None):
         # Autocompleted later with data from the short name.
-        self.category     = ''
-        self.long_name    = name
-        self.short_name   = shortname
-        self.compact_name = compactname
-        self.aliasof      = aliasof
-        self.TGDB_plat    = TGDB_plat
-        self.MG_plat      = MG_plat
-        self.SS_plat      = SS_plat
-        self.GF_plat      = GF_plat
-        self.DAT          = DAT
-        self.DAT_prefix   = DAT_prefix
+        self.category         = ''
+        self.long_name        = name
+        self.short_name       = shortname
+        self.compact_name     = compactname
+        self.aliasof          = aliasof
+        self.TGDB_plat        = TGDB_plat
+        self.MG_plat          = MG_plat
+        self.SS_plat          = SS_plat
+        self.GF_plat          = GF_plat
+        self.DAT              = DAT
+        self.DAT_prefix       = DAT_prefix
+        self.default_box_size = default_box_size
 
 # * From this list create simplified lists to access platform information.
 # * Shorted alphabetically by long name. Alphabetical order is veryfied with script
@@ -218,7 +221,8 @@ AEL_platforms = [
     Platform('Microsoft MSX2', 'microsoft-msx2', 'msx2', None, '4929', '57', '116', '40',
         DAT_NOINTRO, 'Microsoft - MSX2'),
     # MobyGames differentiates Windows = '3' and Windows 3.x = '5'
-    Platform('Microsoft Windows', 'microsoft-windows', 'windows', None, '1', '3', '136', '19', DAT_NONE),
+    Platform('Microsoft Windows', 'microsoft-windows', 'windows', None, '1', '3', '136', '19', DAT_NONE,
+              default_box_size=BOX_SIZE_STEAM),
     Platform('Microsoft Xbox', 'microsoft-xbox', 'xbox', None, '14', '13', '32', '98', DAT_NONE),
     Platform('Microsoft Xbox 360', 'microsoft-xbox360', 'xbox360', None, '15', '69', '33', '111', DAT_NONE),
     Platform('Microsoft Xbox One', 'microsoft-xboxone', 'xboxone', None, '4920', '142', None, '121', DAT_NONE),
@@ -287,15 +291,15 @@ AEL_platforms = [
     Platform('Nintendo Famicon Disk System', 'nintendo-fds', 'fds', None, '4936', '22', '106', '47',
         DAT_NOINTRO, 'Nintendo - Family Computer Disk System (FDS) (Parent-Clone)'),
     Platform('Nintendo GameBoy', 'nintendo-gb', 'gb', None, '4', '10', '9', '59',
-        DAT_NOINTRO, 'Nintendo - Game Boy'),
+        DAT_NOINTRO, 'Nintendo - Game Boy', default_box_size=BOX_SIZE_SQUARE),
     Platform('Nintendo GameBoy Advance', 'nintendo-gba', 'gba', None, '5', '12', '12', '91',
-        DAT_NOINTRO, 'Nintendo - Game Boy Advance'),
+        DAT_NOINTRO, 'Nintendo - Game Boy Advance', default_box_size=BOX_SIZE_SQUARE),
     Platform('Nintendo GameBoy Color', 'nintendo-gbcolor', 'gbcolor', None, '41', '11', '10', '57',
-        DAT_NOINTRO, 'Nintendo - Game Boy Color'),
+        DAT_NOINTRO, 'Nintendo - Game Boy Color', default_box_size=BOX_SIZE_SQUARE),
     Platform('Nintendo GameCube', 'nintendo-gamecube', 'gamecube', None, '2', '14', '13', '99',
-        DAT_REDUMP, 'Nintendo - GameCube - Datfile'),
+        DAT_REDUMP, 'Nintendo - GameCube - Datfile', default_box_size=BOX_SIZE_DVD),
     Platform('Nintendo NES', 'nintendo-nes', 'nes', None, '7', '22', '3', '41',
-        DAT_NOINTRO, 'Nintendo - Nintendo Entertainment System (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - Nintendo Entertainment System (Parent-Clone)', default_box_size=BOX_SIZE_POSTER),
     # No-Intro New Nintendo 3DS DAT files:
     # *) Nintendo - New Nintendo 3DS (Decrypted) (20190402-125456)
     # *) Nintendo - New Nintendo 3DS (Digital) (20181009-100544)
@@ -310,7 +314,7 @@ AEL_platforms = [
     Platform('Nintendo Satellaview', 'nintendo-satellaview', 'satellaview', None, None, None, '107', None,
         DAT_NOINTRO, 'Nintendo - Satellaview'),
     Platform('Nintendo SNES', 'nintendo-snes', 'snes', None, '6', '15', '4', '63',
-        DAT_NOINTRO, 'Nintendo - Super Nintendo Entertainment System (Combined) (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - Super Nintendo Entertainment System (Combined) (Parent-Clone)', default_box_size=BOX_SIZE_WIDE),
     Platform('Nintendo Sufami Turbo', 'nintendo-sufami', 'sufami', None, None, None, '108', None,
         DAT_NOINTRO, 'Nintendo - Sufami Turbo'),
     Platform('Nintendo Switch', 'nintendo-switch', 'switch', None, '4971', '203', None, '124', DAT_NONE),
@@ -394,9 +398,9 @@ AEL_platforms = [
     Platform('Sony PlayStation', 'sony-psx', 'psx', None, '10', '6', '57', '78',
         DAT_REDUMP, 'Sony - PlayStation - Datfile'),
     Platform('Sony PlayStation 2', 'sony-ps2', 'ps2', None, '11', '7', '58', '94',
-        DAT_REDUMP, 'Sony - PlayStation 2 - Datfile'),
-    Platform('Sony PlayStation 3', 'sony-ps3', 'ps3', None, '12', '81', '59', '113', DAT_NONE),
-    Platform('Sony PlayStation 4', 'sony-ps4', 'ps4', None, '4919', '141', None, '120', DAT_NONE),
+        DAT_REDUMP, 'Sony - PlayStation 2 - Datfile', default_box_size=BOX_SIZE_DVD),
+    Platform('Sony PlayStation 3', 'sony-ps3', 'ps3', None, '12', '81', '59', '113', DAT_NONE, default_box_size=BOX_SIZE_BLURAY),
+    Platform('Sony PlayStation 4', 'sony-ps4', 'ps4', None, '4919', '141', None, '120', DAT_NONE, default_box_size=BOX_SIZE_BLURAY),
     # No-Intro has PSP DATs:
     # *) Sony - PlayStation Portable (20191005-125849)
     # *) Sony - PlayStation Portable (Parent-Clone) (20191005-125849)
@@ -412,9 +416,10 @@ AEL_platforms = [
     #
     # Should the Redump or No-Intro DAT used for PSP?
     Platform('Sony PlayStation Portable', 'sony-psp', 'psp', None, '13', '46', '61', '109',
-        DAT_REDUMP, 'Sony - PlayStation Portable - Datfile'),
+        DAT_REDUMP, 'Sony - PlayStation Portable - Datfile', default_box_size=BOX_SIZE_SLIM),
     # No-Intro has PS Vita DATs.
-    Platform('Sony PlayStation Vita', 'sony-psvita', 'psvita', None, '39', '105', '62', '117', DAT_NONE),
+    Platform('Sony PlayStation Vita', 'sony-psvita', 'psvita', None, '39', '105', '62', '117', DAT_NONE, 
+             default_box_size=BOX_SIZE_BLURAY),
 
     Platform('Tiger Game.com', 'console-tigergame', 'tigergame', None, '4940', '50', '121', None,
         DAT_NOINTRO, 'Tiger - Game.com'),
@@ -461,6 +466,10 @@ def get_AEL_platform_index(platform_long):
         return platform_long_to_index_dic[platform_long]
     else:
         return platform_long_to_index_dic[PLATFORM_UNKNOWN_LONG]
+
+def get_AEL_platform(platform_long):
+    idx = get_AEL_platform_index(platform_long)
+    return AEL_platform_list[idx]
 
 # NOTE must take into account platform aliases.
 # '0' means any platform in TGDB and must be returned when there is no platform matching.

--- a/resources/platforms.py
+++ b/resources/platforms.py
@@ -73,38 +73,40 @@ class Platform:
 AEL_platforms = [
     # --- 3DO Interactive Multiplayer ---
     Platform('3DO Interactive Multiplayer', 'console-3do', '3do', None, '25', '35', '29', '61',
-        DAT_REDUMP, 'Panasonic - 3DO Interactive Multiplayer - Datfile'),
+        DAT_REDUMP, 'Panasonic - 3DO Interactive Multiplayer - Datfile', default_box_size=BOX_SIZE_SLIM),
 
     # --- Amstrad ---
-    Platform('Amstrad CPC', 'computer-cpc', 'cpc', None, '4914', '60', '65', '46', DAT_NONE),
+    Platform('Amstrad CPC', 'computer-cpc', 'cpc', None, '4914', '60', '65', '46', DAT_NONE, 
+             default_box_size=BOX_SIZE_POSTER),
 
     # --- Atari ---
     Platform('Atari 2600', 'atari-2600', 'a2600', None, '22', '28', '26', '6',
-        DAT_NOINTRO, 'Atari - 2600'),
+        DAT_NOINTRO, 'Atari - 2600', default_box_size=BOX_SIZE_POSTER),
     Platform('Atari 5200', 'atari-5200', 'a5200', None, '26', '33', '40', '20',
-        DAT_NOINTRO, 'Atari - 5200'),
+        DAT_NOINTRO, 'Atari - 5200', default_box_size=BOX_SIZE_POSTER),
     Platform('Atari 7800', 'atari-7800', 'a7800', None, '27', '34', '41', '51',
-        DAT_NOINTRO, 'Atari - 7800'),
+        DAT_NOINTRO, 'Atari - 7800', default_box_size=BOX_SIZE_POSTER),
     # Atari 8-bit includes: Atari 400, Atari 800, Atari 1200XL, Atari 65XE, Atari 130XE, Atari XEGS
-    Platform('Atari 8-bit', 'computer-atari-8bit', 'atari-8bit', None, '30', '39', '43', None, DAT_NONE),
+    Platform('Atari 8-bit', 'computer-atari-8bit', 'atari-8bit', None, '30', '39', '43', None, DAT_NONE, 
+             default_box_size=BOX_SIZE_POSTER),
     # Atari Jaguar No-Intro DATs:
     # *) Atari - Jaguar (J64) (20190518-213240).dat
     # *) Atari - Jaguar (J64) (Parent-Clone) (Parent-Clone) (20190518-213240).dat
     # *) Atari - Jaguar (ROM) (20190518-213240).dat
     Platform('Atari Jaguar', 'atari-jaguar', 'jaguar', None, '28', '17', '27', '72',
-        DAT_NOINTRO, 'Atari - Jaguar (J64) (Parent-Clone)'),
+        DAT_NOINTRO, 'Atari - Jaguar (J64) (Parent-Clone)', default_box_size=BOX_SIZE_POSTER),
     Platform('Atari Jaguar CD', 'atari-jaguarcd', 'jaguarcd', None, '29', '17', '171', '82',
-        DAT_REDUMP, 'Atari - Jaguar CD Interactive Multimedia System - Datfile'),
+        DAT_REDUMP, 'Atari - Jaguar CD Interactive Multimedia System - Datfile', default_box_size=BOX_SIZE_POSTER),
     Platform('Atari Lynx', 'atari-lynx', 'lynx', None, '4924', '18', '28', '58',
-        DAT_NOINTRO, 'Atari - Lynx'),
+        DAT_NOINTRO, 'Atari - Lynx', default_box_size=BOX_SIZE_POSTER),
     Platform('Atari ST', 'computer-atari-st', 'atari-st', None, '4937', '24', '42', '38',
-        DAT_NOINTRO, 'Atari - ST'),
+        DAT_NOINTRO, 'Atari - ST', default_box_size=BOX_SIZE_POSTER),
 
     # --- Bandai ---
     Platform('Bandai WonderSwan', 'bandai-wswan', 'wswan', None, '4925', '48', '45', '90',
-        DAT_NOINTRO, 'Bandai - WonderSwan'),
+        DAT_NOINTRO, 'Bandai - WonderSwan', default_box_size=BOX_SIZE_POSTER),
     Platform('Bandai WonderSwan Color', 'bandai-wswancolor', 'wswancolor', None, '4926', '49', '46', '95',
-        DAT_NOINTRO, 'Bandai - WonderSwan Color'),
+        DAT_NOINTRO, 'Bandai - WonderSwan Color', default_box_size=BOX_SIZE_POSTER),
 
     Platform('Benesse Pocket Challenge V2', 'console-bpc', 'bpc', None, None, None, None, None,
         DAT_NOINTRO, 'Benesse - Pocket Challenge V2'),
@@ -125,17 +127,17 @@ AEL_platforms = [
     # *) Commodore - 64 (PP) (Parent-Clone) (20131204-081826).dat
     # *) Commodore - 64 (Tapes) (Parent-Clone) (20180307-232531).dat
     Platform('Commodore 64', 'computer-c64', 'c64', None, '40', '27', '66', '24',
-        DAT_NOINTRO, 'Commodore - 64'),
+        DAT_NOINTRO, 'Commodore - 64', default_box_size=BOX_SIZE_POSTER),
     Platform('Commodore Amiga', 'computer-amiga', 'amiga', None, '4911', '19', '64', '39',
-        DAT_NOINTRO, 'Commodore - Amiga'),
+        DAT_NOINTRO, 'Commodore - Amiga', default_box_size=BOX_SIZE_POSTER),
     # The CD32 is part of a family of Amiga computers and is of similar specification to the
     # Amiga 1200 computer.
     Platform('Commodore Amiga CD32', 'console-cd32', 'cd32', None, '4947', '56', '130', '70',
-        DAT_REDUMP, 'Commodore - Amiga CD32 - Datfile'),
+        DAT_REDUMP, 'Commodore - Amiga CD32 - Datfile', default_box_size=BOX_SIZE_POSTER),
     # The CDTV is essentially a Commodore Amiga 500 home computer with a CD-ROM drive and
     # remote control.
     Platform('Commodore Amiga CDTV', 'console-cdtv', 'cdtv', None, None, '83', '129', None,
-        DAT_REDUMP, 'Commodore - Amiga CDTV - Datfile'),
+        DAT_REDUMP, 'Commodore - Amiga CDTV - Datfile', default_box_size=BOX_SIZE_POSTER),
     # MobyGames "Commodore 16, Plus/4"
     # Not found in GameFAQs.
     Platform('Commodore Plus-4', 'computer-plus4', 'plus4', None, None, '115', '99', None,
@@ -208,14 +210,15 @@ AEL_platforms = [
         DAT_NOINTRO, 'Magnavox - Odyssey2'),
 
     # --- MAME/Arcade ---
-    Platform('MAME', 'arcade-mame', 'mame', None, '23', '143', '75', '2', DAT_MAME),
+    Platform('MAME', 'arcade-mame', 'mame', None, '23', '143', '75', '2', DAT_MAME, default_box_size=BOX_SIZE_SCREEN),
 
     # --- Mattel ---
     Platform('Mattel Intellivision', 'console-ivision', 'ivision', None, '32', '30', '115', '16',
         DAT_NOINTRO, 'Mattel - Intellivision'),
 
     # --- Microsoft ---
-    Platform('Microsoft MS-DOS', 'microsoft-msdos', 'msdos', None, '1', '2', '135', '19', DAT_NONE),
+    Platform('Microsoft MS-DOS', 'microsoft-msdos', 'msdos', None, '1', '2', '135', '19', DAT_NONE,
+             default_box_size=BOX_SIZE_POSTER),
     Platform('Microsoft MSX', 'microsoft-msx', 'msx', None, '4929', '57', '113', '40',
         DAT_NOINTRO, 'Microsoft - MSX'),
     Platform('Microsoft MSX2', 'microsoft-msx2', 'msx2', None, '4929', '57', '116', '40',
@@ -223,9 +226,12 @@ AEL_platforms = [
     # MobyGames differentiates Windows = '3' and Windows 3.x = '5'
     Platform('Microsoft Windows', 'microsoft-windows', 'windows', None, '1', '3', '136', '19', DAT_NONE,
               default_box_size=BOX_SIZE_STEAM),
-    Platform('Microsoft Xbox', 'microsoft-xbox', 'xbox', None, '14', '13', '32', '98', DAT_NONE),
-    Platform('Microsoft Xbox 360', 'microsoft-xbox360', 'xbox360', None, '15', '69', '33', '111', DAT_NONE),
-    Platform('Microsoft Xbox One', 'microsoft-xboxone', 'xboxone', None, '4920', '142', None, '121', DAT_NONE),
+    Platform('Microsoft Xbox', 'microsoft-xbox', 'xbox', None, '14', '13', '32', '98', DAT_NONE,
+             default_box_size=BOX_SIZE_DVD),
+    Platform('Microsoft Xbox 360', 'microsoft-xbox360', 'xbox360', None, '15', '69', '33', '111', DAT_NONE,
+             default_box_size=BOX_SIZE_DVD),
+    Platform('Microsoft Xbox One', 'microsoft-xboxone', 'xboxone', None, '4920', '142', None, '121', DAT_NONE,
+             default_box_size=BOX_SIZE_BLURAY),
 
     # --- NEC ---
     Platform('NEC PC Engine', 'nec-pce', 'pce', None, '34', '40', '31', '53',
@@ -252,16 +258,16 @@ AEL_platforms = [
     # *) Nintendo - Nintendo 3DS (Encrypted) (20191109-080816)
     # *) Nintendo - Nintendo 3DS (Encrypted) (Parent-Clone) (Parent-Clone) (20191109-080816)
     Platform('Nintendo 3DS', 'nintendo-n3ds', 'n3ds', None, '4912', '101', '17', '116',
-        DAT_NOINTRO, 'Nintendo - Nintendo 3DS (Encrypted) (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - Nintendo 3DS (Encrypted) (Parent-Clone)', default_box_size=BOX_SIZE_3DS),
     # No-Intro Nintendo 64 DAT files:
     # *) Nintendo - Nintendo 64 (BigEndian) (20190918-121135)
     # *) Nintendo - Nintendo 64 (BigEndian) (Parent-Clone) (Parent-Clone) (20190918-121135)
     # *) Nintendo - Nintendo 64 (ByteSwapped) (20190918-121135)
     Platform('Nintendo 64', 'nintendo-n64', 'n64', None, '3', '9', '14', '84',
-        DAT_NOINTRO, 'Nintendo - Nintendo 64 (BigEndian) (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - Nintendo 64 (BigEndian) (Parent-Clone)', default_box_size=BOX_SIZE_WIDE),
     # Nintendo 64DD not found on MobyGames.
     Platform('Nintendo 64DD', 'nintendo-n64dd', 'n64dd', None, '3', '9', '122', '92',
-        DAT_NOINTRO, 'Nintendo - Nintendo 64DD'),
+        DAT_NOINTRO, 'Nintendo - Nintendo 64DD', default_box_size=BOX_SIZE_WIDE),
     # No-Intro Nintendo DS DAT files:
     # *) Nintendo - Nintendo DS (Decrypted) (20191117-150815)
     # *) Nintendo - Nintendo DS (Decrypted) (Parent-Clone) (Parent-Clone) (20191117-150815)
@@ -269,7 +275,7 @@ AEL_platforms = [
     # *) Nintendo - Nintendo DS (Download Play) (Parent-Clone) (20190825-082425)
     # *) Nintendo - Nintendo DS (Encrypted) (20191117-150815)
     Platform('Nintendo DS', 'nintendo-nds', 'nds', None, '8', '44', '15', '108',
-        DAT_NOINTRO, 'Nintendo - Nintendo DS (Decrypted) (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - Nintendo DS (Decrypted) (Parent-Clone)', default_box_size=BOX_SIZE_3DS),
     # No-Intro Nintendo DSi DAT files:
     # *) Nintendo - Nintendo DSi (Decrypted) (20190503-112150)
     # *) Nintendo - Nintendo DSi (Decrypted) (Parent-Clone) (Parent-Clone) (20190503-112150)
@@ -277,10 +283,10 @@ AEL_platforms = [
     # *) Nintendo - Nintendo DSi (Digital) (Parent-Clone) (20190813-061824)
     # *) Nintendo - Nintendo DSi (Encrypted) (20190503-112150)
     Platform('Nintendo DSi', 'nintendo-ndsi', 'ndsi', None, '8', '87', '15', '108',
-        DAT_NOINTRO, 'Nintendo - Nintendo DSi (Decrypted) (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - Nintendo DSi (Decrypted) (Parent-Clone)', default_box_size=BOX_SIZE_3DS),
     Platform('Nintendo e-Reader', 'nintendo-ereader', 'ereader', None, None, None, '119', None,
         DAT_NOINTRO, 'Nintendo - e-Reader'),
-    Platform('Nintendo Famicon', 'nintendo-famicon', 'famicon', 'nes'),
+    Platform('Nintendo Famicon', 'nintendo-famicon', 'famicon', 'nes', default_box_size=BOX_SIZE_WIDE),
     # FDS not found on MobyGames, make same as NES.
     # FDS No-Intro DAT files:
     # *) Nintendo - Family Computer Disk System (FDS) (20191109-080316)
@@ -289,7 +295,7 @@ AEL_platforms = [
     # *) Nintendo - Family Computer Disk System (FDSStickRAW) (20191109-080316)
     # *) Nintendo - Family Computer Disk System (QD) (20191109-080316)
     Platform('Nintendo Famicon Disk System', 'nintendo-fds', 'fds', None, '4936', '22', '106', '47',
-        DAT_NOINTRO, 'Nintendo - Family Computer Disk System (FDS) (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - Family Computer Disk System (FDS) (Parent-Clone)', default_box_size=BOX_SIZE_WIDE),
     Platform('Nintendo GameBoy', 'nintendo-gb', 'gb', None, '4', '10', '9', '59',
         DAT_NOINTRO, 'Nintendo - Game Boy', default_box_size=BOX_SIZE_SQUARE),
     Platform('Nintendo GameBoy Advance', 'nintendo-gba', 'gba', None, '5', '12', '12', '91',
@@ -307,7 +313,7 @@ AEL_platforms = [
     # *) Nintendo - New Nintendo 3DS (Encrypted) (20190402-125456)
     # *) Nintendo - New Nintendo 3DS (Encrypted) (Parent-Clone) (Parent-Clone) (20190402-125456)
     Platform('Nintendo New Nintendo 3DS', 'nintendo-new3ds', 'new3ds', None, None, None, None, None,
-        DAT_NOINTRO, 'Nintendo - New Nintendo 3DS (Encrypted) (Parent-Clone)'),
+        DAT_NOINTRO, 'Nintendo - New Nintendo 3DS (Encrypted) (Parent-Clone)', default_box_size=BOX_SIZE_3DS),
     # Pokemon Mini not found in GameFAQs.
     Platform('Nintendo Pokemon Mini', 'nintendo-pokemini', 'pokemini', None, '4957', '152', '211', None,
         DAT_NOINTRO, 'Nintendo - Pokemon Mini'),
@@ -317,12 +323,15 @@ AEL_platforms = [
         DAT_NOINTRO, 'Nintendo - Super Nintendo Entertainment System (Combined) (Parent-Clone)', default_box_size=BOX_SIZE_WIDE),
     Platform('Nintendo Sufami Turbo', 'nintendo-sufami', 'sufami', None, None, None, '108', None,
         DAT_NOINTRO, 'Nintendo - Sufami Turbo'),
-    Platform('Nintendo Switch', 'nintendo-switch', 'switch', None, '4971', '203', None, '124', DAT_NONE),
+    Platform('Nintendo Switch', 'nintendo-switch', 'switch', None, '4971', '203', None, '124', DAT_NONE, 
+             default_box_size=BOX_SIZE_SLIM),
     Platform('Nintendo Virtual Boy', 'nintendo-vb', 'vb', None, '4918', '38', '11', '83',
         DAT_NOINTRO, 'Nintendo - Virtual Boy'),
     # No-Intro has some DATs for Wii and Wii U with tags Digital, CDN and WAD.
-    Platform('Nintendo Wii', 'nintendo-wii', 'wii', None, '9', '82', '16', '114', DAT_NONE),
-    Platform('Nintendo Wii U', 'nintendo-wiiu', 'wiiu', None, '38', '132', '18', '118', DAT_NONE),
+    Platform('Nintendo Wii', 'nintendo-wii', 'wii', None, '9', '82', '16', '114', DAT_NONE, 
+             default_box_size=BOX_SIZE_DVD),
+    Platform('Nintendo Wii U', 'nintendo-wiiu', 'wiiu', None, '38', '132', '18', '118', DAT_NONE,
+             default_box_size=BOX_SIZE_DVD),
 
     Platform('Ouya Ouya', 'console-ouya', 'ouya', None, '4921', '144', None, None,
         DAT_NOINTRO, 'Ouya - Ouya'),
@@ -343,25 +352,25 @@ AEL_platforms = [
 
     # --- Sega ---
     Platform('Sega 32X', 'sega-32x', '32x', None, '33', '21', '19', '74',
-        DAT_NOINTRO, 'Sega - 32X'),
+        DAT_NOINTRO, 'Sega - 32X', default_box_size=BOX_SIZE_DVD),
     # The Advanced Pico Beena is an upgraded Sega PICO.
     Platform('Sega Beena', 'sega-beena', 'beena', None, None, None, None, None,
         DAT_NOINTRO, 'Sega - Beena'),
     Platform('Sega Dreamcast', 'sega-dreamcast', 'dreamcast', None, '16', '8', '23', '67',
-        DAT_REDUMP, 'Sega - Dreamcast - Datfile'),
+        DAT_REDUMP, 'Sega - Dreamcast - Datfile', default_box_size=BOX_SIZE_DVD),
     Platform('Sega Game Gear', 'sega-gamegear', 'gamegear', None, '20', '25', '21', '62',
         DAT_NOINTRO, 'Sega - Game Gear'),
-    Platform('Sega Genesis', 'sega-genesis', 'genesis', 'megadrive'),
+    Platform('Sega Genesis', 'sega-genesis', 'genesis', 'megadrive', default_box_size=BOX_SIZE_POSTER),
     Platform('Sega Master System', 'sega-sms', 'sms', None, '35', '26', '2', '49',
-        DAT_NOINTRO, 'Sega - Master System - Mark III'),
+        DAT_NOINTRO, 'Sega - Master System - Mark III', default_box_size=BOX_SIZE_POSTER),
     Platform('Sega Mega Drive', 'sega-megadrive', 'megadrive', None, '36', '16', '1', '54',
-        DAT_NOINTRO, 'Sega - Mega Drive - Genesis'),
+        DAT_NOINTRO, 'Sega - Mega Drive - Genesis', default_box_size=BOX_SIZE_POSTER),
     Platform('Sega MegaCD', 'sega-megacd', 'megacd', None, '21', '20', '20', '65',
-        DAT_REDUMP, 'Sega - Mega CD & Sega CD - Datfile'),
+        DAT_REDUMP, 'Sega - Mega CD & Sega CD - Datfile', default_box_size=BOX_SIZE_POSTER),
     Platform('Sega PICO', 'sega-pico', 'pico', None, '4958', '103', None, None,
         DAT_NOINTRO, 'Sega - PICO'),
     Platform('Sega Saturn', 'sega-saturn', 'saturn', None, '17', '23', '22', '76',
-        DAT_REDUMP, 'Sega - Saturn - Datfile'),
+        DAT_REDUMP, 'Sega - Saturn - Datfile', default_box_size=BOX_SIZE_SLIM),
     # The SG-1000 was released in several forms, including the SC-3000 computer and
     # the redesigned SG-1000 II.
     Platform('Sega SC-3000', 'sega-sc3000', 'sc3000', 'sg1000'),
@@ -396,7 +405,7 @@ AEL_platforms = [
 
     # --- SONY ---
     Platform('Sony PlayStation', 'sony-psx', 'psx', None, '10', '6', '57', '78',
-        DAT_REDUMP, 'Sony - PlayStation - Datfile'),
+        DAT_REDUMP, 'Sony - PlayStation - Datfile', default_box_size=BOX_SIZE_DVD),
     Platform('Sony PlayStation 2', 'sony-ps2', 'ps2', None, '11', '7', '58', '94',
         DAT_REDUMP, 'Sony - PlayStation 2 - Datfile', default_box_size=BOX_SIZE_DVD),
     Platform('Sony PlayStation 3', 'sony-ps3', 'ps3', None, '12', '81', '59', '113', DAT_NONE, default_box_size=BOX_SIZE_BLURAY),

--- a/resources/scrap.py
+++ b/resources/scrap.py
@@ -433,9 +433,9 @@ class ScrapeStrategy(object):
             self.pdialog.updateProgress(num_items_checked)
             num_items_checked = num_items_checked + 1
             ROM_file = rom.get_file()
-            file_text = 'ROM {0}'.format(ROM_file.getBase())
+            file_text = 'ROM {}'.format(ROM_file.getBase())
             
-            self.pdialog.updateMessages(file_text, 'Scraping {0}...'.format(ROM_file.getBaseNoExt()))
+            self.pdialog.updateMessages(file_text, 'Scraping {}...'.format(ROM_file.getBaseNoExt()))
             try:
                 self.scanner_process_ROM(rom, ROM_file)
             except Exception as ex:
@@ -5058,7 +5058,6 @@ class GoogleImageSearch(Scraper):
 
         return asset_list
     
-
     # Retrieve URL and create a JSON object.
     # GoogleImageSearch
     #

--- a/resources/scrap.py
+++ b/resources/scrap.py
@@ -125,7 +125,8 @@ class ScraperSettings(object):
         self.game_selection_mode    = SCRAPE_AUTOMATIC
         self.asset_selection_mode   = SCRAPE_AUTOMATIC
         
-        self.asset_IDs_to_scrape = ROM_ASSET_ID_LIST       
+        self.asset_IDs_to_scrape = ROM_ASSET_ID_LIST
+        self.overwrite_existing = False
         self.show_info_verbose = False
     
     def build_menu(self):
@@ -135,6 +136,7 @@ class ScraperSettings(object):
         options['SC_ASSET_POLICY']         = 'Asset scan policy: "{}"'.format(text_translate(self.scrape_assets_policy))
         options['SC_GAME_SELECTION_MODE']  = 'Game selection mode: "{}"'.format(text_translate(self.game_selection_mode))
         options['SC_ASSET_SELECTION_MODE'] = 'Asset selection mode: "{}"'.format(text_translate(self.asset_selection_mode))
+        options['SC_OVERWRITE_MODE']       = 'Overwrite existing files: "{}"'.format('Yes' if self.overwrite_existing else 'No')
         options['SC_METADATA_SCRAPER']     = 'Metadata scraper: "{}"'.format(text_translate(self.metadata_scraper_ID))
         options['SC_ASSET_SCRAPER']        = 'Asset scraper: "{}"'.format(text_translate(self.assets_scraper_ID))
         
@@ -551,7 +553,10 @@ class ScrapeStrategy(object):
         for AInfo in self.enabled_asset_list:
             if self.asset_action_list[AInfo.id] == ScrapeStrategy.ACTION_ASSET_NONE:
                 log_debug('Skipping asset scraping for {}'.format(AInfo.name))
-                continue                
+                continue    
+            elif not self.scraper_settings.overwrite_existing and ROM.has_asset(AInfo):
+                log_debug('Asset {} already exists. Skipping (no overwrite)'.format(AInfo.name))
+                continue
             elif self.asset_action_list[AInfo.id] == ScrapeStrategy.ACTION_ASSET_LOCAL_ASSET:
                 log_debug('Using local asset for {}'.format(AInfo.name))
                 ROM.set_asset(AInfo, self.local_asset_list[AInfo.id])

--- a/resources/utils.py
+++ b/resources/utils.py
@@ -799,9 +799,9 @@ def misc_search_file_cache(dir_path, filename_noext, file_exts):
     current_cache_set = file_cache[dir_str]
     for ext in file_exts:
         file_base = filename_noext + '.' + ext
-        file_base = file_base.lower()
+        file_base_as_cached = file_base.lower()
         #log_debug('misc_search_file_cache() file_Base = "{0}"'.format(file_base))
-        if file_base in current_cache_set:
+        if file_base_as_cached in current_cache_set:
             # log_debug('misc_search_file_cache() Found in cache')
             return dir_path.pjoin(file_base)
 


### PR DESCRIPTION
Reenabled some skin support by setting some AEL launcher info in windows properties.
Added box size information to launchers which is initially set by the selected platform but can be overridden by the user. Helps with skinning to automatically apply correct view size.